### PR TITLE
Revert "Issue #1: Override method hashCode() because class overrides …

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/stats/TrackStatistics.java
+++ b/src/main/java/de/dennisguse/opentracks/stats/TrackStatistics.java
@@ -383,14 +383,6 @@ public class TrackStatistics {
         return toString().equals(o.toString());
     }
 
-    @Override
-    public int hashCode() {
-        final int primeNumber = 31;
-        int result = 1;
-        result = result * primeNumber + (startTime == null ? 0 : startTime.hashCode());
-        return result;
-    }
-
     @NonNull
     @Override
     public String toString() {


### PR DESCRIPTION
# Thanks for your contribution.

Description:
Classes overriding equals() method must also override hashCode() method in order for the class functionality to work correctly. In the TrackStatistics.java class, equals() method has been defined while hashCode() is not.

Location of the issue: TrackStatistics.java
File path: src/main/java/de/dennisguse/opentracks/stats/TrackStatistics.java

Reason for change: To make sure, class functionality works correctly when containers like map are used.

Link to the the issue:
https://github.com/SonamChugh13/OpenTracks-Group3-SOEN-6431_2024/issues/2#issue-2128559358

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.
