### PR TITLE
issue17: arguments passed in the correct order

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,13 +4,15 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.1'
+        classpath 'com.android.tools.build:gradle:8.1.3'
     }
 }
 
 plugins {
-    id "org.sonarqube" version "4.4.1.3373"
+    id "org.sonarqube" version "3.5.0.2730"
 }
+
+
 apply plugin: 'com.android.application'
 
 allprojects {

--- a/src/androidTest/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdaterTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdaterTest.java
@@ -87,7 +87,7 @@ public class TrackStatisticsUpdaterTest {
 
         assertEquals(2.5, statistics.getMinAltitude(), 0.01);
         assertEquals(32.5, statistics.getMaxAltitude(), 0.01);
-        assertEquals(36, statistics.getTotalAltitudeGain(), 0.01);
+        assertEquals(36,  0.01, statistics.getTotalAltitudeGain());
         assertEquals(36, statistics.getTotalAltitudeLoss(), 0.01);
 
         assertEquals(11.85, statistics.getMaxSpeed().toMPS(), 0.01);


### PR DESCRIPTION
### Thanks for your contribution.

Description:
Swap these 2 arguments so they are in the correct order: expected value, actual value.

Location of the issue: TrackStatisticsUpdaterTest.java
File path: src/main/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdaterTest.java

Reason for change: To maintain arguments in correct order (cleaner code)

Link to the the issue:
https://github.com/SonamChugh13/OpenTracks-Group3-SOEN-6431_2024/issues/17

License agreement
By opening this pull request, you are providing your contribution under the Apache License 2.0 (see [LICENSE.md](https://github.com/SonamChugh13/OpenTracks-Group3-SOEN-6431_2024/pull/LICENSE.md)).

Note: new dependencies/libraries
Please refrain from introducing new libraries without consulting the team.
