### PR TITLE
Add new screen for ski profile

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/settings/MainSettingsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/MainSettingsFragment.java
@@ -25,6 +25,11 @@ public class MainSettingsFragment extends PreferenceFragmentCompat {
             return true;
         });
 
+        findPreference(getString(R.string.settings_ski_profile_key)).setOnPreferenceClickListener(preference -> {
+            ((SettingsActivity) getActivity()).openScreen(getString(R.string.settings_ski_profile_key));
+            return true;
+        });
+
         findPreference(getString(R.string.settings_gps_key)).setOnPreferenceClickListener(preference -> {
             ((SettingsActivity) getActivity()).openScreen(getString(R.string.settings_gps_key));
             return true;

--- a/src/main/java/de/dennisguse/opentracks/settings/SettingsActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/SettingsActivity.java
@@ -84,6 +84,8 @@ public class SettingsActivity extends AbstractActivity implements ChooseActivity
             fragment = new DefaultsSettingsFragment();
         } else if (key.equals(getString(R.string.settings_ui_key))) {
             fragment = new UserInterfaceSettingsFragment();
+        } else if (key.equals(getString(R.string.settings_ski_profile_key))) {
+            fragment = new UserProfileSettingsFragment();
         } else if (key.equals(getString(R.string.settings_gps_key))) {
             fragment = new GpsSettingsFragment();
         } else if (key.equals(getString(R.string.settings_sensors_key))) {

--- a/src/main/java/de/dennisguse/opentracks/settings/UserProfileSettingsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/UserProfileSettingsFragment.java
@@ -1,0 +1,13 @@
+package de.dennisguse.opentracks.settings;
+
+import android.os.Bundle;
+
+import androidx.annotation.Nullable;
+import androidx.preference.PreferenceFragmentCompat;
+
+public class UserProfileSettingsFragment extends PreferenceFragmentCompat {
+    @Override
+    public void onCreatePreferences(@Nullable Bundle savedInstanceState, @Nullable String rootKey) {
+
+    }
+}


### PR DESCRIPTION
**Describe the pull request**
Implement a blank screen when the user clicks on the ski profile subsection.

**Link to the the issue**
 Related to issue [#84](https://github.com/rilling/OpenTracks-Winter-SOEN-6431_2024/issues/84)

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).