### PR TITLE
Added name and phone number for ski profile screen

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.2'
+        classpath 'com.android.tools.build:gradle:8.1.3'
     }
 }
 

--- a/src/main/java/de/dennisguse/opentracks/settings/UserProfileSettingsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/UserProfileSettingsFragment.java
@@ -1,13 +1,88 @@
 package de.dennisguse.opentracks.settings;
 
+import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.text.Editable;
+import android.text.InputFilter;
+import android.text.TextUtils;
+import android.text.TextWatcher;
 
 import androidx.annotation.Nullable;
+import androidx.preference.EditTextPreference;
+import androidx.preference.ListPreference;
 import androidx.preference.PreferenceFragmentCompat;
 
+import de.dennisguse.opentracks.R;
+
 public class UserProfileSettingsFragment extends PreferenceFragmentCompat {
+
+    private final SharedPreferences.OnSharedPreferenceChangeListener sharedPreferenceChangeListener = (sharedPreferences, key) -> {
+        if (PreferencesUtils.isKey(R.string.night_mode_key, key)) {
+            getActivity().runOnUiThread(PreferencesUtils::applyNightMode);
+        }
+    };
     @Override
     public void onCreatePreferences(@Nullable Bundle savedInstanceState, @Nullable String rootKey) {
+        addPreferencesFromResource(R.xml.settings_ski_profile);
+    }
 
+    @Override
+    public void onStart() {
+        super.onStart();
+        ((SettingsActivity) getActivity()).getSupportActionBar().setTitle(R.string.settings_ski_profile_title);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        EditTextPreference nameInput = findPreference(getString(R.string.settings_ski_profile_name_key));
+        nameInput.setDialogTitle(getString(R.string.settings_ski_profile_name_dialog_title));
+        nameInput.setOnBindEditTextListener(editText -> {
+            editText.setSingleLine(true);
+            editText.selectAll(); // select all text
+            int maxNameLength = 20;
+            editText.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxNameLength)});
+        });
+
+        EditTextPreference phoneInput = findPreference(getString(R.string.settings_ski_profile_phone_key));
+        phoneInput.setDialogTitle(getString(R.string.settings_ski_profile_phone_dialog_title));
+        phoneInput.setOnBindEditTextListener(editText -> {
+            editText.setSingleLine(true);
+            editText.selectAll(); // select all text
+            InputFilter inputFilter = (source, start, end, dest, dstart, dend) -> {
+                if (TextUtils.isDigitsOnly(source)) {
+                    if (dest.length() + source.length() <= 10) {
+                        return null; // Accept the input
+                    }
+                }
+                return ""; // Reject the input
+            };
+            editText.setFilters(new InputFilter[]{inputFilter});
+            editText.addTextChangedListener(new TextWatcher() {
+                @Override
+                public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+
+                @Override
+                public void onTextChanged(CharSequence s, int start, int before, int count) {}
+
+                @Override
+                public void afterTextChanged(Editable s) {
+                    if (s.length() < 10) {
+                        editText.setError(getString(R.string.settings_ski_profile_phone_error)); // Set error message
+                    } else {
+                        editText.setError(null);
+                    }
+                }
+            });
+        });
+
+        PreferencesUtils.registerOnSharedPreferenceChangeListener(sharedPreferenceChangeListener);
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        PreferencesUtils.unregisterOnSharedPreferenceChangeListener(sharedPreferenceChangeListener);
     }
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -349,6 +349,13 @@ limitations under the License.
 
     <string name="settings_ski_profile_title">Ski Profile</string>
     <string name="settings_ski_profile_summary">Favorite Ski Resorts, Sharpening Info, Waxing Info, Ski Info, Statistics</string>
+    <string name="settings_ski_profile_name">Name</string>
+    <string name="settings_ski_profile_name_dialog_title">Name (max 20 char)</string>
+    <string name="settings_ski_profile_name_key" translatable="false">Name</string>
+    <string name="settings_ski_profile_phone">Phone</string>
+    <string name="settings_ski_profile_phone_dialog_title">Enter your phone number</string>
+    <string name="settings_ski_profile_phone_error">Phone number must contain at least 10 digits</string>
+    <string name="settings_ski_profile_phone_key" translatable="false">Phone</string>
 
     <string name="settings_gps_title">GPS</string>
     <string name="settings_gps_summary">Time interval, Distance interval, Max Distance, Accuracy</string>

--- a/src/main/res/xml/settings_ski_profile.xml
+++ b/src/main/res/xml/settings_ski_profile.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:title="@string/settings_ski_profile_title">
+    <EditTextPreference
+        android:inputType="text"
+        android:key="@string/settings_ski_profile_name_key"
+        android:title="@string/settings_ski_profile_name"
+        app:useSimpleSummaryProvider="true" />
+
+    <EditTextPreference
+        android:inputType="phone"
+        android:key="@string/settings_ski_profile_phone_key"
+        android:title="@string/settings_ski_profile_phone"
+        app:useSimpleSummaryProvider="true" />
+
+</PreferenceScreen>


### PR DESCRIPTION
**Describe the pull request**
Added name and phone number fields for ski profile screen.

**Link to the the issue**
 Related to issue [#108](https://github.com/rilling/OpenTracks-Winter-SOEN-6431_2024/issues/108)

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).